### PR TITLE
Support configuration of UDP receive buffer size

### DIFF
--- a/udp_driver/include/boost_udp_driver/udp_driver.hpp
+++ b/udp_driver/include/boost_udp_driver/udp_driver.hpp
@@ -39,6 +39,8 @@ public:
     const std::string & remote_ip, uint16_t remote_port,
     const std::string & host_ip, uint16_t host_port);
   void init_receiver(const std::string & ip, uint16_t port);
+  void init_receiver(const std::string & ip, uint16_t port, size_t buffer_size);
+
 
   std::shared_ptr<UdpSocket> sender() const;
   std::shared_ptr<UdpSocket> receiver() const;

--- a/udp_driver/include/boost_udp_driver/udp_socket.hpp
+++ b/udp_driver/include/boost_udp_driver/udp_socket.hpp
@@ -40,7 +40,16 @@ public:
     const std::string & host_ip, uint16_t host_port);
   UdpSocket(
     const drivers::common::IoContext & ctx,
+    const std::string & remote_ip, uint16_t remote_port,
+    const std::string & host_ip, uint16_t host_port, 
+    size_t recv_buffer_size);
+  UdpSocket(
+    const drivers::common::IoContext & ctx,
     const std::string & ip, uint16_t port);
+  UdpSocket(
+    const drivers::common::IoContext & ctx,
+    const std::string & ip, uint16_t port,
+    size_t recv_buffer_size);
   ~UdpSocket();
 
   UdpSocket(const UdpSocket &) = delete;
@@ -91,7 +100,8 @@ private:
   boost::asio::ip::udp::endpoint m_remote_endpoint;
   boost::asio::ip::udp::endpoint m_host_endpoint;
   Functor m_func;
-  static const size_t m_recv_buffer_size{2048};
+  static constexpr size_t m_default_recv_buffer_size{2048};
+  size_t m_recv_buffer_size;
   std::vector<uint8_t> m_recv_buffer;
 };
 

--- a/udp_driver/src/udp_driver.cpp
+++ b/udp_driver/src/udp_driver.cpp
@@ -47,6 +47,12 @@ void UdpDriver::init_receiver(const std::string & ip, uint16_t port)
   m_receiver.reset(new UdpSocket(m_ctx, ip, port));
 }
 
+void UdpDriver::init_receiver(const std::string & ip, uint16_t port, size_t buffer_size)
+{
+  m_receiver.reset(new UdpSocket(m_ctx, ip, port, buffer_size));
+}
+
+
 std::shared_ptr<UdpSocket> UdpDriver::sender() const
 {
   return m_sender;

--- a/udp_driver/src/udp_socket.cpp
+++ b/udp_driver/src/udp_socket.cpp
@@ -35,11 +35,13 @@ UdpSocket::UdpSocket(
   const std::string & remote_ip,
   const uint16_t remote_port,
   const std::string & host_ip,
-  const uint16_t host_port)
+  const uint16_t host_port, 
+  const size_t recv_buffer_size)
 : m_ctx(ctx),
   m_udp_socket(ctx.ios()),
   m_remote_endpoint(boost::asio::ip::address::from_string(remote_ip), remote_port),
-  m_host_endpoint(boost::asio::ip::address::from_string(host_ip), host_port)
+  m_host_endpoint(boost::asio::ip::address::from_string(host_ip), host_port),
+  m_recv_buffer_size(recv_buffer_size)
 {
   m_remote_endpoint = remote_ip.empty() ?
     boost::asio::ip::udp::endpoint{boost::asio::ip::udp::v4(), remote_port} :
@@ -47,8 +49,25 @@ UdpSocket::UdpSocket(
   m_host_endpoint = host_ip.empty() ?
     boost::asio::ip::udp::endpoint{boost::asio::ip::udp::v4(), host_port} :
   boost::asio::ip::udp::endpoint{boost::asio::ip::address::from_string(host_ip), host_port};
-  m_recv_buffer.resize(m_recv_buffer_size);
+  m_recv_buffer.resize(recv_buffer_size);
 }
+
+UdpSocket::UdpSocket(
+  const drivers::common::IoContext & ctx,
+  const std::string & remote_ip,
+  const uint16_t remote_port,
+  const std::string & host_ip,
+  const uint16_t host_port) 
+  : UdpSocket(ctx, remote_ip, remote_port, host_ip, host_port, m_default_recv_buffer_size)
+  {}
+
+UdpSocket::UdpSocket(
+  const drivers::common::IoContext & ctx,
+  const std::string & ip,
+  const uint16_t port,
+  const size_t recv_buffer_size)
+: UdpSocket{ctx, ip, port, ip, port, recv_buffer_size}
+{}
 
 UdpSocket::UdpSocket(
   const drivers::common::IoContext & ctx,


### PR DESCRIPTION
This PR adds the ability to pass the wanted UDP receive buffer size when calling the init_receiver function of the UdpDriver.
Previously the receive buffer was hard coded to 2048. This will remain the default value, so this PR should have no effect on any existing code using this library. 